### PR TITLE
CI: Add PHP 8.2, 8.3, and 8.4 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.4', '8.0', '8.1']
+        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Updates the GitHub Actions workflow file (`.github/workflows/test.yml`) to include PHP versions 8.2, 8.3, and 8.4 in the test matrix.

This will ensure your package is tested against more recent PHP versions, improving compatibility and robustness.